### PR TITLE
When deregistering a backend, delete it from mysql_servers table.

### DIFF
--- a/proxysql_tools/managers/proxysql_manager.py
+++ b/proxysql_tools/managers/proxysql_manager.py
@@ -115,9 +115,7 @@ class ProxySQLManager(object):
             log.info('Deregistering backend %s:%s in hostgroup %s' %
                      (backend.hostname, backend.port, backend.hostgroup_id))
 
-            return self.update_mysql_backend_status(
-                backend.hostgroup_id, backend.hostname, backend.port,
-                BACKEND_STATUS_OFFLINE_HARD)
+            return self.delete_mysql_backend(backend, proxy_conn)
 
     def update_mysql_backend_status(self, hostgroup_id, hostname, port,
                                     status):
@@ -372,6 +370,32 @@ class ProxySQLManager(object):
             log.debug('Executing query: %s' % sql)
 
             cursor.execute(sql)
+            cursor.execute('SAVE MYSQL SERVERS TO DISK')
+
+            if self.should_reload_runtime:
+                cursor.execute('LOAD MYSQL SERVERS TO RUNTIME')
+
+        return True
+
+    def delete_mysql_backend(self, backend, proxy_conn):
+        """Delete the MySQL backend registered with ProxySQL.
+
+        :param backend: The MySQL backend server.
+        :type backend: ProxySQLMySQLBackend
+        :param proxy_conn: A connection to ProxySQL.
+        :type proxy_conn: Connection
+        :return: True on success, False otherwise.
+        :rtype: bool
+        """
+        backend.validate()
+        with proxy_conn.cursor() as cursor:
+            sql = ("DELETE FROM mysql_servers "
+                   "WHERE hostgroup_id=%s AND hostname=%s AND port=%s")
+
+            log.debug('Executing query: %s' % sql)
+
+            cursor.execute(sql, (backend.hostgroup_id, backend.hostname,
+                                 backend.port))
             cursor.execute('SAVE MYSQL SERVERS TO DISK')
 
             if self.should_reload_runtime:

--- a/proxysql_tools/managers/proxysql_manager.py
+++ b/proxysql_tools/managers/proxysql_manager.py
@@ -6,7 +6,7 @@ from pymysql.err import OperationalError
 
 from proxysql_tools import log
 from proxysql_tools.entities.proxysql import (
-    ProxySQLMySQLBackend, ProxySQLMySQLUser, BACKEND_STATUS_OFFLINE_HARD
+    ProxySQLMySQLBackend, ProxySQLMySQLUser
 )
 
 PROXYSQL_CONNECT_TIMEOUT = 20

--- a/tests/integration/managers/test_proxysql_manager.py
+++ b/tests/integration/managers/test_proxysql_manager.py
@@ -2,7 +2,6 @@ import pytest
 
 from proxysql_tools.entities.proxysql import (
     BACKEND_STATUS_OFFLINE_SOFT,
-    BACKEND_STATUS_OFFLINE_HARD,
     ProxySQLMySQLBackend,
     ProxySQLMySQLUser
 )

--- a/tests/integration/managers/test_proxysql_manager.py
+++ b/tests/integration/managers/test_proxysql_manager.py
@@ -96,7 +96,10 @@ def test__mysql_backend_can_be_deregistered(proxysql_manager):
         backend.hostgroup_id, backend.hostname, backend.port)
     backends_list = proxysql_manager.fetch_backends()
 
-    assert backends_list.pop().status == BACKEND_STATUS_OFFLINE_HARD
+    with proxysql_manager.get_connection() as conn:
+        assert not proxysql_manager.is_mysql_backend_registered(backend, conn)
+
+    assert len(backends_list) == 0
 
 
 def test__can_register_mysql_user(proxysql_manager):

--- a/tests/unit/test_proxysql_manager.py
+++ b/tests/unit/test_proxysql_manager.py
@@ -1,0 +1,55 @@
+from doubles import allow, expect
+from mock import MagicMock
+
+from proxysql_tools.entities.proxysql import ProxySQLMySQLBackend
+from proxysql_tools.managers.proxysql_manager import ProxySQLManager
+
+
+def test__deregister_backend_deletes_the_backend():
+    proxysql_man = ProxySQLManager('127.0.0.1', 6032, 'username', 'password')
+
+    backend = ProxySQLMySQLBackend({
+        'hostgroup_id': 10,
+        'hostname': 'dummy_host',
+        'port': 3306
+    })
+
+    (allow(proxysql_man)
+        .get_connection
+        .and_return(MagicMock()))
+
+    (allow(proxysql_man)
+        .is_mysql_backend_registered
+        .and_return(True))
+
+    (expect(proxysql_man)
+        .delete_mysql_backend
+        .once())
+
+    proxysql_man.deregister_backend(backend.hostgroup_id, backend.hostname,
+                                    backend.port)
+
+
+def test__deregister_backend_does_not_delete_the_backend_if_not_registered():
+    proxysql_man = ProxySQLManager('127.0.0.1', 6032, 'username', 'password')
+
+    backend = ProxySQLMySQLBackend({
+        'hostgroup_id': 10,
+        'hostname': 'dummy_host',
+        'port': 3306
+    })
+
+    (allow(proxysql_man)
+        .get_connection
+        .and_return(MagicMock()))
+
+    (allow(proxysql_man)
+        .is_mysql_backend_registered
+        .and_return(False))
+
+    (expect(proxysql_man)
+        .delete_mysql_backend
+        .never())
+
+    proxysql_man.deregister_backend(backend.hostgroup_id, backend.hostname,
+                                    backend.port)


### PR DESCRIPTION
Fixes #18.