### PR TITLE
Last node as donor + variables

### DIFF
--- a/proxysql_tools/cli_entrypoint/galera.py
+++ b/proxysql_tools/cli_entrypoint/galera.py
@@ -32,6 +32,11 @@ def galera_register(cfg):
     load_balancing_mode = cfg.get('galera', 'load_balancing_mode')
     writer_hostgroup_id = int(cfg.get('galera', 'writer_hostgroup_id'))
     reader_hostgroup_id = int(cfg.get('galera', 'reader_hostgroup_id'))
+    try:
+        use_last_desynced = cfg.getboolean('galera','use_last_desynced')
+    except NoOptionError:
+        use_last_desynced = None
+        pass
 
     if load_balancing_mode == 'singlewriter':
         kwargs = {}
@@ -41,6 +46,10 @@ def galera_register(cfg):
                                          hostgroup_id=writer_hostgroup_id,
                                          port=port)
             kwargs['ignore_writer'] = bcknd
+        except NoOptionError:
+            pass
+        try:
+            kwargs['use_last_desynced'] = use_last_desynced
         except NoOptionError:
             pass
         singlewriter(galera_cluster, proxysql,

--- a/proxysql_tools/cli_entrypoint/galera.py
+++ b/proxysql_tools/cli_entrypoint/galera.py
@@ -33,10 +33,9 @@ def galera_register(cfg):
     writer_hostgroup_id = int(cfg.get('galera', 'writer_hostgroup_id'))
     reader_hostgroup_id = int(cfg.get('galera', 'reader_hostgroup_id'))
     try:
-        use_last_desynced = cfg.getboolean('galera','use_last_desynced')
+        use_last_desynced = cfg.getboolean('galera', 'use_last_desynced')
     except NoOptionError:
         use_last_desynced = None
-        pass
 
     if load_balancing_mode == 'singlewriter':
         kwargs = {}

--- a/proxysql_tools/galera/galera_cluster.py
+++ b/proxysql_tools/galera/galera_cluster.py
@@ -80,10 +80,11 @@ class GaleraCluster(object):
                         state = galera_node.wsrep_local_state
                         donor_reject = galera_node.wsrep_sst_donor_rejects_queries
                         reject_queries = galera_node.wsrep_reject_queries
-                        LOG.debug('%s state: %s donor reject: %s reject queries: %s', galera_node, state,
-                                  donor_reject, reject_queries)
-                        if state == GaleraNodeState.DONOR and len(nodes) == 0 and donor_reject == "OFF" and reject_queries == "NONE":
-                            nodes.append(galera_node)
+                        length = len(nodes)
+                        LOG.debug('%s state: %s donor reject: %s reject queries: %s',
+                                  galera_node, state, donor_reject, reject_queries)
+                        if state == GaleraNodeState.DONOR and length == 0 and donor_reject == "OFF" and reject_queries == "NONE":
+                                nodes.append(galera_node)
                     except OperationalError as err:
                         LOG.error(err)
                         LOG.info('Skipping node %s', galera_node)

--- a/proxysql_tools/galera/galera_node.py
+++ b/proxysql_tools/galera/galera_node.py
@@ -8,12 +8,12 @@ from proxysql_tools import execute
 
 
 class GaleraNodeState(object):  # pylint: disable=too-few-public-methods
-    """State of Galera node http://bit.ly/2r1tUGB """
-    PRIMARY = 1
-    JOINER = 5 #2
+    """State of Galera node http://bit.ly/2wkXYyY """
+    INITIALIZED = 0
+    JOINING = 1
+    DONOR = 2
     JOINED = 3
     SYNCED = 4
-    DONOR = 2 #5
 
 
 class GaleraNode(object):

--- a/proxysql_tools/galera/galera_node.py
+++ b/proxysql_tools/galera/galera_node.py
@@ -10,10 +10,10 @@ from proxysql_tools import execute
 class GaleraNodeState(object):  # pylint: disable=too-few-public-methods
     """State of Galera node http://bit.ly/2r1tUGB """
     PRIMARY = 1
-    JOINER = 2
+    JOINER = 5 #2
     JOINED = 3
     SYNCED = 4
-    DONOR = 5
+    DONOR = 2 #5
 
 
 class GaleraNode(object):
@@ -50,6 +50,16 @@ class GaleraNode(object):
     def wsrep_local_state(self):
         """Internal Galera Cluster FSM state number."""
         return int(self._status('wsrep_local_state'))
+
+    @property
+    def wsrep_reject_queries(self):
+        """Decides if node rejects queries or not."""
+        return self._variables('wsrep_reject_queries')
+
+    @property
+    def wsrep_sst_donor_rejects_queries(self):
+        """Decides if node rejects queries or not while in Donor/Desync state."""
+        return self._variables('wsrep_sst_donor_rejects_queries')
 
     @property
     def wsrep_cluster_name(self):
@@ -89,6 +99,11 @@ class GaleraNode(object):
     def _status(self, status_variable):
         """Return value of a variable from SHOW GLOBAL STATUS"""
         result = self.execute('SHOW GLOBAL STATUS LIKE %s', status_variable)
+        return result[0]['Value']
+
+    def _variables(self, global_variable):
+        """Return value of a variable from SHOW GLOBAL VARIABLES"""
+        result = self.execute('SHOW GLOBAL VARIABLES LIKE %s', global_variable)
         return result[0]['Value']
 
     def __eq__(self, other):

--- a/proxysql_tools/load_balancing_mode.py
+++ b/proxysql_tools/load_balancing_mode.py
@@ -106,8 +106,7 @@ def register_writer(galera_cluster, proxysql, writer_hostgroup_id,
                           use_last_desynced, limit=1,
                           ignore_backend=ignore_writer,
                           recovered_hostgroup_id=reader_hostgroup_id,
-                          recoverd_comment='Reader'
-                          )
+                          recoverd_comment='Reader')
 
     except ProxySQLBackendNotFound:
         # add it
@@ -289,7 +288,7 @@ def check_backend(backend, galera_cluster, proxysql, hostgroup_id, comment,  # p
 
 def register_synced_backends(galera_cluster, proxysql,  # pylint: disable=too-many-arguments
                              hostgroup_id,
-                             use_last_desynced = None,
+                             use_last_desynced=None,
                              comment=None, limit=None,
                              ignore_backend=None):
     """
@@ -327,7 +326,7 @@ def register_synced_backends(galera_cluster, proxysql,  # pylint: disable=too-ma
             candidate_nodes = galera_nodes
 
         for galera_node in candidate_nodes:
-            LOG.debug('wsrep_reject_queries: {}'.format(galera_node.wsrep_reject_queries))
+            LOG.debug('wsrep_reject_queries: %s', galera_node.wsrep_reject_queries)
             if galera_node.wsrep_reject_queries == "NONE":
                 backend = ProxySQLMySQLBackend(galera_node.host,
                                                hostgroup_id=hostgroup_id,

--- a/support/proxysql-tool.cfg
+++ b/support/proxysql-tool.cfg
@@ -38,3 +38,7 @@ reader_hostgroup_id=11
 
 # The nodes that are blacklisted from becoming a writer
 writer_blacklist=192.168.30.53:3306
+
+# If all nodes are in Donor/Desync state, set one of them online
+# Handles "last node in the cluster used as a Donor" case
+use_last_desynced=1


### PR DESCRIPTION
Added support for a case when last available node becomes a donor - it shouldn't go offline_soft all long as possible. I also added support for handling of wsrep_reject_queries (node doesn't accept any queries -> goes offline_soft) and wsrep_sst_donor_rejects_queries (node doesn't accept queries when in Donor/Desync state -> goes offline_soft).
Feel free to use it, base on it etc.