### PR TITLE
Fix miscase of cli.validate_password docs

### DIFF
--- a/proxysql_tools/cli.py
+++ b/proxysql_tools/cli.py
@@ -281,7 +281,7 @@ def create(cfg, username, password, active, use_ssl,  # pylint: disable=too-many
 
 # noinspection PyUnusedLocal
 def validate_password(ctx, param, value):  # pylint: disable=unused-argument
-    """CHeck password value and confirm again if it's empty."""
+    """Check password value and confirm again if it's empty."""
     if not value:
         password = raw_input("Repeat for confirmation: ")
         if password == '':


### PR DESCRIPTION
Spotted while browsing 💅 

<img width="547" alt="screen shot 2018-02-19 at 14 07 03" src="https://user-images.githubusercontent.com/1000669/36363182-3279ed2a-157e-11e8-8004-89706d02d6f2.png">
